### PR TITLE
 Add attribution APIs (2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2.0.0
+
+* `getReferralInfo()` is now deprecated, use `getAttributionInfo()` instead.
+
+* Introduced `getAttributionInfo()` method.
+    * Returns the same data as `getReferralInfo()` with additional `isFirstLaunch`, `firstInstallTime`, `isConsumed` and `attributionStatus` fields included in the response.
+
+* Introduced `onAttributionListener()` listener.
+    * When an attribution is detected, and again every time the app returns to the foreground so the payload stays current.
+
+* Added `appsFlyer` and `attributionTtl` params to `AppLinkParams` for AppsFlyer attribution support in `createAppLink` method.
+
+**Deprecated:**
+
+* `onReferralLinkDetected()` — use `onAttributionListener()`.
+* `getReferralInfo()` and `getReferralDetails()` — use `getAttributionInfo()`.
+
+
 ## 1.3.3
 
 * Improvements & fixes.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ dependencyResolutionManagement {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Initialize deeplink service and set listener for deep link and referral link events
+        // Initialize deeplink service and set listener for deep link and attribution events
         appLinkService = AppLinkService.getInstance(this)
         // Initialize the AppLink to track the deeplink
         appLinkService.initialize(this, intent, object : AppLinkListener {
@@ -108,9 +108,8 @@ dependencyResolutionManagement {
             override fun onDeepLinkError(uri: Uri?, error: String) {
                 // Handle error when deep link processing fails
             }
-            // Optional method
-            override fun onReferralLinkDetected(result: JSONObject) {
-                 // Perform your action on referral data
+            override fun onAttributionListener(result: JSONObject) {
+                 // Perform your action on attribution data
             }
         })
     }
@@ -135,6 +134,15 @@ dependencyResolutionManagement {
         "imageUrl" to "https://image.png"
     )
 
+    val appsFlyer = mapOf(
+        "channel" to "appsonair",
+        "campaignId" to "01",
+        "campaign" to "test",
+        "subs" to listOf("sub1", "sub2", "sub3", "sub4", "sub5"),
+        "metaTitle" to "metaTitle",
+        "metaDescription" to "metaDescription"
+    )
+
    
 CoroutineScope(Dispatchers.Main).launch {
     val result = appLinkService.createAppLink(
@@ -145,21 +153,64 @@ CoroutineScope(Dispatchers.Main).launch {
         socialMeta = socialMeta,
         androidFallbackUrl = "https://play.google.com",
         isOpenInAndroidApp = true,
-        isOpenInBrowserAndroid = false
+        isOpenInBrowserAndroid = false,
+        appsFlyer = appsFlyer, // Optional
+        attributionTtl = 3600 // Optional
     )
   }
 ```
 
-#### To retrieving the referral link
+#### To retrieving the attribution info
 ```
 CoroutineScope(Dispatchers.Main).launch {
-    val referral = appLinkService.getReferralInfo()
+    val attribution = appLinkService.getAttributionInfo()
 }
 ```
 
-### Note:
+`onAttributionListener()` At first detection, then on the foreground return
+that follows `isFirstLaunch` turning `false`. Gate one time logic on `isFirstLaunch`, not on the
+callback firing.
 
-#### The install referral data is available for up to 90 days. If you need access to it beyond that, you must store it locally within your app.
+Along with the referral details, `getAttributionInfo()` and `onAttributionListener()` add the
+following keys inside the `data` object of the response:
+
+| Response Key | Type | Description |
+| --- | --- | --- |
+| `isFirstLaunch` | Boolean | `true` during the first launch after installation, until the app leaves the foreground. |
+| `firstInstallTime` | Long | Timestamp (epoch milliseconds) of the app's first installation. |
+| `applink_click_time` | Long | Timestamp (epoch milliseconds) of the click this install is attributed to. Absent when the install referrer carried none. |
+| `isConsumed` | Boolean | `true` when `attributionStatus` is `non-organic`. |
+| `attributionStatus` | String | `non-organic` when the install happened within `attributionTtl` of the click, `organic` otherwise. |
+
+
+### Upgrading from 1.3.x
+
+No code change is required: `initialize(context, intent, AppLinkListener)` keeps its signature and
+an existing listener compiles unchanged. `AppLinkListener` gains `onAttributionListener()`, which
+has a default implementation, so override it only when you want the attribution payload:
+
+```sh
+    appLinkService.initialize(this, intent, object : AppLinkListener {
+        override fun onDeepLinkProcessed(uri: Uri, result: JSONObject) { }
+
+        override fun onDeepLinkError(uri: Uri?, error: String) { }
+
+        // New in 2.0.0 — optional
+        override fun onAttributionListener(result: JSONObject) { }
+    })
+```
+
+### Deprecated APIs
+
+Deprecated and removed in a future release. Existing integrations keep working:
+
+| Deprecated | Use instead |
+| --- | --- |
+| `onReferralLinkDetected()` | `onAttributionListener()` |
+| `getReferralInfo()` | `getAttributionInfo()` |
+| `getReferralDetails()` | `getAttributionInfo()` |
+
+### Note:
 
 To test referral functionality, your app must be live on the Play Store. If it's not, you can use the application ID of any live app instead for testing purposes.
 

--- a/app/src/main/java/com/example/appsonair_android_applink/MainActivity.kt
+++ b/app/src/main/java/com/example/appsonair_android_applink/MainActivity.kt
@@ -12,24 +12,36 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,34 +51,69 @@ import com.example.appsonair_android_applink.ui.theme.AppLinkTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.json.JSONArray
 import org.json.JSONObject
 
 
 class MainActivity : ComponentActivity() {
 
     private lateinit var appLinkService: AppLinkService
-    private var deepLinkUrl = ""
+
+    // Each section keeps its own response so the deprecated and attribution
+    // results are never shown in the same place.
+    private var deepLinkResult by mutableStateOf("")
+    private var deprecatedListenerResult by mutableStateOf("")
+    private var deprecatedApiResult by mutableStateOf("")
+    private var attributionListenerResult by mutableStateOf("")
+    private var attributionApiResult by mutableStateOf("")
+    private var createLinkResult by mutableStateOf("")
+    private var isLoading by mutableStateOf(false)
+
+    // createAppLink inputs, mirroring the React Native example's form.
+    private var linkName by mutableStateOf("AppsOnAir")
+    private var linkUrl by mutableStateOf("https://appsonair.com")
+    // urlPrefix shouldn't contain http or https
+    private var urlPrefix by mutableStateOf("")
+    private var shortId by mutableStateOf("")
+    private var androidFallbackUrl by mutableStateOf("")
+    private var iosFallbackUrl by mutableStateOf("")
+    private var attributionTtl by mutableStateOf("")
+    private var isOpenInAndroidApp by mutableStateOf(true)
+    private var isOpenInBrowserAndroid by mutableStateOf(false)
+    private var isOpenInIosApp by mutableStateOf(true)
+    private var isOpenInBrowserApple by mutableStateOf(false)
+
+    // The SDK forwards this dictionary to the API untouched, so it is edited as raw JSON rather
+    // than fixed fields — any keys beyond the documented ones are passed through as-is.
+    private var appsFlyerJson by mutableStateOf(
+        """
+        {
+          "channel": "appsonair",
+          "campaignId": "01",
+          "campaign": "test",
+          "subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],
+          "metaTitle": "metaTitle",
+          "metaDescription": "metaDescription"
+        }
+        """.trimIndent()
+    )
 
     // Called when the activity is created. Initializes AppLinkService and sets up deep link handling.
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Initialize deeplink service and set listener for deep link and referral link events
+        // Initialize deeplink service and set listener for deep link and attribution events
         appLinkService = AppLinkService.getInstance(this)
-        // Initialize the AppLink to track the deeplink and referral tracking.
+
+        // AppLinkListener is the only listener, and it serves both surfaces: it carries the
+        // deprecated onReferralLinkDetected() alongside onAttributionListener(), and the SDK gives
+        // each its own payload.
         appLinkService.initialize(this, intent, object : AppLinkListener {
             override fun onDeepLinkProcessed(uri: Uri, result: JSONObject) {
                 // Store the processed deep link URL and log the parameters
-                deepLinkUrl = uri.toString()
-                Log.d(
-                    "DeepLinkListener",
-                    "Deep link Result -->$result"
-                )
-                Log.d(
-                    "DeepLinkListener",
-                    "Deep link Link -->$deepLinkUrl"
-                )
-                setUI(result.toString()) // Update UI with the deep link URL
+                Log.d("DeepLinkListener", "Deep link Result -->$result")
+                Log.d("DeepLinkListener", "Deep link Link -->$uri")
+                deepLinkResult = result.toString() // Update UI with the deep link result
             }
 
             override fun onDeepLinkError(uri: Uri?, error: String) {
@@ -74,13 +121,20 @@ class MainActivity : ComponentActivity() {
                 Log.e("DeepLinkListener", "Failed to process deep link: $uri, Error: $error")
             }
 
+            override fun onAttributionListener(result: JSONObject) {
+                attributionListenerResult = result.toString()
+            }
+
+            // Deprecated, kept here only to compare its payload with onAttributionListener():
+            // the referral only, with no appsFlyer object and none of the attribution fields.
+            @Deprecated("Use onAttributionListener instead")
             override fun onReferralLinkDetected(result: JSONObject) {
-                setUI(result.toString()) // Update UI with the deep link URL
+                deprecatedListenerResult = result.toString()
             }
         })
 
-        // Update UI with the current deep link URL
-        setUI(deepLinkUrl)
+        enableEdgeToEdge()
+        setContent { AppLinkScreen() }
     }
 
     // Called when the app is resumed with a new intent (deep link).
@@ -90,122 +144,315 @@ class MainActivity : ComponentActivity() {
             intent,
             "com.example.appsonair_android_applink"
         ) // Handle deep link
-        setUI(deepLinkUrl) // Update UI with the deep link URL
     }
 
-    // Sets the UI based on the provided URL, displaying either the deep link or a fallback message.
+    /** Reads the AppsFlyer JSON box. Returns null when it is blank or cannot be parsed. */
+    private fun parseAppsFlyer(): Map<String, Any>? {
+        val trimmed = appsFlyerJson.trim()
+        if (trimmed.isEmpty()) return null
+        return try {
+            jsonToMap(JSONObject(trimmed))
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun jsonToMap(json: JSONObject): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+        json.keys().forEach { key ->
+            map[key] = when (val value = json.get(key)) {
+                is JSONObject -> jsonToMap(value)
+                is JSONArray -> jsonToList(value)
+                else -> value
+            }
+        }
+        return map
+    }
+
+    private fun jsonToList(array: JSONArray): List<Any> =
+        (0 until array.length()).map { index ->
+            when (val value = array.get(index)) {
+                is JSONObject -> jsonToMap(value)
+                is JSONArray -> jsonToList(value)
+                else -> value
+            }
+        }
+
     @OptIn(ExperimentalMaterial3Api::class)
-    private fun setUI(url: String) {
-        enableEdgeToEdge()
-        setContent {
-            AppLinkTheme {
-                var isLoading by remember { mutableStateOf(false) }
-                Box(
+    @Composable
+    private fun AppLinkScreen() {
+        AppLinkTheme {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.White)
+            ) {
+                // Main Scaffold content
+                Scaffold(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Color.White)
-                ) {
-                    // Main Scaffold content
-                    Scaffold(
+                        .background(color = Color.White),
+                    topBar = {
+                        CenterAlignedTopAppBar(
+                            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                titleContentColor = Color.Black,
+                            ),
+                            title = {
+                                Text(
+                                    getString(R.string.simulate_deep_link),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            },
+                        )
+                    },
+                ) { innerPadding ->
+                    // Column for the main content
+                    Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .background(color = Color.White),
-                        topBar = {
-                            CenterAlignedTopAppBar(
-                                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                    titleContentColor = MaterialTheme.colorScheme.primary,
-                                ),
-                                title = {
-                                    Text(
-                                        getString(R.string.simulate_deep_link),
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                },
-                            )
-                        },
-                    ) { innerPadding ->
-                        // Column for the main content
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(innerPadding)
-                                .background(color = Color.White),
-                            verticalArrangement = Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            // Display deep link or fallback message
-                            Box(contentAlignment = Alignment.Center) {
-                                Text(
-                                    text = "Link==> ${url.ifEmpty { "No link found!!" }}",
-                                    fontSize = 18.sp,
-                                    color = Color.Black,
-                                    modifier = Modifier
-                                        .padding(30.dp)
-                                        .background(Color(0xFFFFFFFF))
-                                )
-                            }
+                            .padding(innerPadding)
+                            .background(color = Color.White)
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.Top,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        ResponseSection("Deep Link", deepLinkResult)
 
-                            // Button to get the referral link
-                            ElevatedButton(onClick = {
-                                CoroutineScope(Dispatchers.Main).launch {
-                                    val referral = appLinkService.getReferralInfo()
-                                    setUI(referral.toString()) // Update UI with referral link
-                                }
-                            }) {
-                                Text("Get Referral Link")
-                            }
+                        Divider()
 
-                            // Button to trigger API call
-                            ElevatedButton(
-                                onClick = {
-                                    isLoading = true // Show loader
-                                    val socialMeta = mapOf(
-                                        "title" to "link title",
-                                        "description" to "link description",
-                                        "imageUrl" to "https://image.com"
-                                    )
+                        ResponseSection(
+                            "Deprecated — onReferralLinkDetected()",
+                            deprecatedListenerResult
+                        )
+                        ResponseSection(
+                            "Deprecated — getReferralDetails() / getReferralInfo()",
+                            deprecatedApiResult
+                        )
 
-                                    CoroutineScope(Dispatchers.Main).launch {
-                                        val result = appLinkService.createAppLink(
-                                            name = "AppsOnAir",
-                                            url = "https://appsonair.com",
-                                            urlPrefix = "YOUR_DOMAIN_NAME", //shouldn't contain http or https
-                                            androidFallbackUrl = "https://play.google.com",
-                                            socialMeta = socialMeta,
-                                            isOpenInAndroidApp = true,
-                                            isOpenInBrowserAndroid = false
-                                        )
-                                        Log.d("API response==>", result.toString())
-                                        setUI(result.toString())
-                                        isLoading = false // Hide loader
-                                    }
-                                },
-                                Modifier.padding(16.dp)
-                            ) {
-                                Text("Create Link")
-                            }
+                        // Button to get the referral details (deprecated)
+                        ElevatedButton(onClick = {
+                            val referral = appLinkService.getReferralDetails()
+                            deprecatedApiResult = referral.toString()
+                        }) {
+                            Text("Get Referral Details (Deprecated)")
                         }
-                    }
 
-                    if (isLoading) {
-                        // Overlay for loader
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(Color(0x80000000)) // Semi-transparent background
-                                .pointerInput(Unit) {} // Blocks all touch interactions
-                                .clickable(enabled = false) {}, // Prevent clicks
-                            contentAlignment = Alignment.Center
+                        // Button to get the referral info (deprecated)
+                        ElevatedButton(onClick = {
+                            CoroutineScope(Dispatchers.Main).launch {
+                                val referral = appLinkService.getReferralInfo()
+                                deprecatedApiResult = referral.toString()
+                            }
+                        }) {
+                            Text("Get Referral Info (Deprecated)")
+                        }
+
+                        Divider()
+
+                        ResponseSection(
+                            "Attribution — onAttributionListener()",
+                            attributionListenerResult
+                        )
+                        ResponseSection(
+                            "Attribution — getAttributionInfo()",
+                            attributionApiResult
+                        )
+
+                        // Button to get the attribution info
+                        ElevatedButton(onClick = {
+                            CoroutineScope(Dispatchers.Main).launch {
+                                val attribution = appLinkService.getAttributionInfo()
+                                attributionApiResult = attribution.toString()
+                            }
+                        }) {
+                            Text("Get Attribution Info")
+                        }
+
+                        Divider()
+
+                        SectionTitle("Create AppLink")
+
+                        LabeledTextField("Name", linkName) { linkName = it }
+                        LabeledTextField("URL", linkUrl) { linkUrl = it }
+                        LabeledTextField("URL Prefix", urlPrefix) { urlPrefix = it }
+                        LabeledTextField("Short ID", shortId) { shortId = it }
+                        LabeledTextField("Android Fallback URL", androidFallbackUrl) {
+                            androidFallbackUrl = it
+                        }
+                        LabeledTextField("iOS Fallback URL", iosFallbackUrl) {
+                            iosFallbackUrl = it
+                        }
+                        LabeledTextField(
+                            "Attribution TTL (seconds)",
+                            attributionTtl,
+                            keyboardType = KeyboardType.Number
+                        ) { attributionTtl = it }
+                        LabeledTextField(
+                            "AppsFlyer params (JSON, any keys allowed)",
+                            appsFlyerJson,
+                            singleLine = false,
+                            minLines = 6
+                        ) { appsFlyerJson = it }
+
+                        LabeledSwitch("Open in Android App", isOpenInAndroidApp) {
+                            isOpenInAndroidApp = it
+                        }
+                        LabeledSwitch("Open in Android Browser", isOpenInBrowserAndroid) {
+                            isOpenInBrowserAndroid = it
+                        }
+                        LabeledSwitch("Open in iOS App", isOpenInIosApp) { isOpenInIosApp = it }
+                        LabeledSwitch("Open in iOS Browser", isOpenInBrowserApple) {
+                            isOpenInBrowserApple = it
+                        }
+
+                        ResponseSection("Create Link", createLinkResult)
+
+                        // Button to trigger API call
+                        ElevatedButton(
+                            onClick = {
+                                // Parsed before the call so malformed JSON is reported on its own
+                                // rather than as an API failure.
+                                val appsFlyer = parseAppsFlyer()
+                                if (appsFlyer == null && appsFlyerJson.isNotBlank()) {
+                                    createLinkResult =
+                                        "Invalid AppsFlyer JSON — fix the JSON and try again."
+                                    return@ElevatedButton
+                                }
+
+                                isLoading = true // Show loader
+
+                                val socialMeta = mapOf(
+                                    "title" to "link title",
+                                    "description" to "link description",
+                                    "imageUrl" to "https://image.com"
+                                )
+
+                                CoroutineScope(Dispatchers.Main).launch {
+                                    val result = appLinkService.createAppLink(
+                                        name = linkName,
+                                        url = linkUrl,
+                                        urlPrefix = urlPrefix,
+                                        shortId = shortId.takeIf { it.isNotBlank() },
+                                        socialMeta = socialMeta,
+                                        isOpenInAndroidApp = isOpenInAndroidApp,
+                                        isOpenInBrowserAndroid = isOpenInBrowserAndroid,
+                                        androidFallbackUrl = androidFallbackUrl,
+                                        isOpenInIosApp = isOpenInIosApp,
+                                        isOpenInBrowserApple = isOpenInBrowserApple,
+                                        iosFallbackUrl = iosFallbackUrl,
+                                        appsFlyer = appsFlyer,
+                                        attributionTtl = attributionTtl.trim().toIntOrNull()
+                                    )
+                                    Log.d("API response==>", result.toString())
+                                    createLinkResult = result.toString()
+                                    isLoading = false // Hide loader
+                                }
+                            },
+                            Modifier.padding(16.dp)
                         ) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.padding(top = 16.dp),
-                                color = Color.Blue
-                            )
+                            Text("Create Link")
                         }
                     }
                 }
+
+                if (isLoading) {
+                    // Overlay for loader
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color(0x80000000)) // Semi-transparent background
+                            .pointerInput(Unit) {} // Blocks all touch interactions
+                            .clickable(enabled = false) {}, // Prevent clicks
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.padding(top = 16.dp),
+                            color = Color.Blue
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun SectionTitle(title: String) {
+        Text(
+            text = title,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = Color.Black,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 4.dp)
+        )
+    }
+
+    @Composable
+    private fun LabeledTextField(
+        label: String,
+        value: String,
+        keyboardType: KeyboardType = KeyboardType.Text,
+        singleLine: Boolean = true,
+        minLines: Int = 1,
+        onValueChange: (String) -> Unit
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(label) },
+            singleLine = singleLine,
+            minLines = minLines,
+            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = Color.Black,
+                unfocusedTextColor = Color.Black,
+                focusedLabelColor = Color.Black,
+                unfocusedLabelColor = Color.Black,
+                cursorColor = Color.Black,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp)
+        )
+    }
+
+    @Composable
+    private fun LabeledSwitch(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = label, fontSize = 14.sp, color = Color.Black)
+            Switch(checked = checked, onCheckedChange = onCheckedChange)
+        }
+    }
+
+    @Composable
+    private fun ResponseSection(title: String, value: String) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            Text(
+                text = title,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.Black
+            )
+            // Selectable so the response can be long pressed and copied off the device
+            SelectionContainer {
+                Text(
+                    text = value.ifEmpty { "No data yet" },
+                    fontSize = 12.sp,
+                    color = Color.Black
+                )
             }
         }
     }

--- a/applink/build.gradle.kts
+++ b/applink/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.appsonair"
-version = "1.3.3"
+version = "2.0.0"
 
 val projectProperties = listOf(
     "BASE_URL",
@@ -71,7 +71,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "com.appsonair"
             artifactId = "applink"
-            version = "1.3.3"
+            version = "2.0.0"
 
             // Wait for Android to finish configuration
             afterEvaluate {

--- a/applink/src/main/java/com/appsonair/applink/interfaces/AppLinkListener.kt
+++ b/applink/src/main/java/com/appsonair/applink/interfaces/AppLinkListener.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import org.json.JSONObject
 
 /**
- * overriding onReferralLinkDetected is optional you can call it as per your requirement for install tracking
+ * overriding onAttributionListener is optional you can call it as per your requirement for install tracking
  */
 interface AppLinkListener {
     /**
@@ -24,8 +24,28 @@ interface AppLinkListener {
     fun onDeepLinkError(uri: Uri?, error: String) // appLinkError
 
     /**
-     * Called when a deep link is successfully processed.
-     * @param result The extracted data from the server for the link.
+     * Fires at most twice: when an attribution is detected, then once more on the return to the
+     * foreground that follows `isFirstLaunch` turning `false`, re-delivering the persisted payload
+     * without refetching so the listener sees that flip. Later foreground returns are silent.
+     * Gate one time logic on [isFirstLaunch].
+     *
+     * @param result The attribution data along with [isFirstLaunch], [firstInstallTime],
+     * [isConsumed] and [attributionStatus].
      */
+    fun onAttributionListener(result: JSONObject) {}
+
+    /**
+     * Called when a referral link is detected, carrying the referral payload in its original
+     * shape: no `appsFlyer` object and none of the attribution fields.
+     *
+     * Detection only — unlike [onAttributionListener] it is not re-delivered when the app returns
+     * to the foreground.
+     *
+     * Provided here so one listener can serve both surfaces, for wrappers that still read the
+     * referral payload.
+     *
+     * @param result The referral data, without the newer attribution surface.
+     */
+    @Deprecated(message = "Use onAttributionListener() instead")
     fun onReferralLinkDetected(result: JSONObject) {}
 }

--- a/applink/src/main/java/com/appsonair/applink/services/AppLinkHandler.kt
+++ b/applink/src/main/java/com/appsonair/applink/services/AppLinkHandler.kt
@@ -22,7 +22,8 @@ internal class AppLinkHandler {
         @JvmStatic
         suspend fun fetchAppLink(
             linkId: String,
-            domain: String
+            domain: String,
+            publicUserAgent: String
         ): JSONObject {
             val isNetworkConnected = NetworkWatcherService.isNetworkConnected
             if (!isNetworkConnected) {
@@ -34,12 +35,16 @@ internal class AppLinkHandler {
 
             val request = Request.Builder()
                 .url(appLinkURL).addHeader(StringConst.ApplicatonKey, appsOnAirAppId)
+                .addHeader(StringConst.SdkVersionKey, BuildConfig.VERSION_NAME)
+                .addHeader("User-Agent", publicUserAgent)
                 .get()
                 .build()
 
             return withContext(Dispatchers.IO) {
                 try {
                     val response = client.newCall(request).execute()
+                    // Server clock, used to keep attributionTtl off the editable device clock.
+                    ServerTimeService.recordServerDate(response.header("Date"))
 
                     if (response.isSuccessful) {
                         val responseBody = response.body?.string().orEmpty()
@@ -78,6 +83,8 @@ internal class AppLinkHandler {
             isOpenInBrowserApple: Boolean? = null,
             isOpenInIosApp: Boolean? = null,
             iosFallbackUrl: String? = null,
+            appsFlyer: Map<String, Any>? = null,
+            attributionTtl: Int? = null,
         ): JSONObject {
             // Some of the params are not used as we keep it for future user will remove if not needed in future i.e [customParams, analytics, isShortLink]
             val isNetworkConnected = NetworkWatcherService.isNetworkConnected
@@ -107,6 +114,8 @@ internal class AppLinkHandler {
                                     put("imageUrl", it["imageUrl"] ?: JSONObject.NULL)
                                 })
                             }
+                            appsFlyer?.let { put("appsFlyer", JSONObject(it)) }
+                            attributionTtl?.let { put("attributionTtl", it) }
                             androidFallbackUrl?.let { put("customUrlForAndroid", it) }
                             iosFallbackUrl?.let { put("customUrlForIos", it) }
                             isOpenInBrowserApple?.let { put("isOpenInBrowserApple", it) }
@@ -171,12 +180,15 @@ internal class AppLinkHandler {
 
             val request = Request.Builder()
                 .url(appLinkURL).addHeader(StringConst.ApplicatonKey, appsOnAirAppId)
+                .addHeader(StringConst.SdkVersionKey, BuildConfig.VERSION_NAME)
                 .post(body)
                 .build()
 
             return withContext(Dispatchers.IO) {
                 try {
                     val response = client.newCall(request).execute()
+                    // Server clock, used to keep attributionTtl off the editable device clock.
+                    ServerTimeService.recordServerDate(response.header("Date"))
                     if (response.isSuccessful) {
                         val responseBody = response.body?.string().orEmpty()
                         JSONObject(responseBody) // Return the response directly
@@ -206,19 +218,23 @@ internal class AppLinkHandler {
             isClicked: Boolean = true,
             isFirstOpen: Boolean = false,
             isInstall: Boolean = false,
+            onResult: ((Boolean) -> Unit)? = null,
         ) {
             val isNetworkConnected = NetworkWatcherService.isNetworkConnected
             if (appsOnAirAppId.isEmpty()) {
                 Log.e("AppLink", StringConst.AppIdMissing)
+                onResult?.invoke(false)
                 return
             }
 
             if (!isNetworkConnected) {
                 Log.e("error", StringConst.NetworkError)
+                onResult?.invoke(false)
                 return
             }
 
             Thread {
+                var isSuccessful = false
                 try {
                     val json = "application/json; charset=utf-8".toMediaType()
                     val appLinkURL = BuildConfig.BASE_URL + StringConst.LinkAnalytics
@@ -235,11 +251,15 @@ internal class AppLinkHandler {
                     val request = Request.Builder()
                         .url(appLinkURL)
                         .addHeader(StringConst.ApplicatonKey, appsOnAirAppId)
+                        .addHeader(StringConst.SdkVersionKey, BuildConfig.VERSION_NAME)
                         .post(body)
                         .build()
 
                     val response = client.newCall(request).execute()
-                    if (response.isSuccessful) {
+                    // Server clock, used to keep attributionTtl off the editable device clock.
+                    ServerTimeService.recordServerDate(response.header("Date"))
+                    isSuccessful = response.isSuccessful
+                    if (isSuccessful) {
                         Log.d("AppLink", "Analytics Added")
                     } else {
                         Log.e("AppLink", "Analytics failed: ${response.code}")
@@ -247,6 +267,7 @@ internal class AppLinkHandler {
                 } catch (e: Exception) {
                     Log.e("AppLink", "API call exception: ${e.localizedMessage}")
                 }
+                onResult?.invoke(isSuccessful)
             }.start()
         }
 
@@ -262,6 +283,7 @@ internal class AppLinkHandler {
             val client = OkHttpClient()
             val request = Request.Builder()
                 .url(appLinkURL).addHeader(StringConst.ApplicatonKey, appsOnAirAppId)
+                .addHeader(StringConst.SdkVersionKey, BuildConfig.VERSION_NAME)
                 .addHeader("User-Agent", publicUserAgent ?: "")
                 .get()
                 .build()
@@ -269,6 +291,8 @@ internal class AppLinkHandler {
             return withContext(Dispatchers.IO) {
                 try {
                     val response = client.newCall(request).execute()
+                    // Server clock, used to keep attributionTtl off the editable device clock.
+                    ServerTimeService.recordServerDate(response.header("Date"))
 
                     if (response.isSuccessful) {
                         val responseBody = response.body?.string().orEmpty()

--- a/applink/src/main/java/com/appsonair/applink/services/AppLinkService.kt
+++ b/applink/src/main/java/com/appsonair/applink/services/AppLinkService.kt
@@ -1,9 +1,12 @@
 package com.appsonair.applink.services
 
 import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import android.util.Log
 import android.webkit.WebView
 import androidx.core.net.toUri
@@ -11,14 +14,19 @@ import com.android.installreferrer.api.InstallReferrerClient
 import com.android.installreferrer.api.InstallReferrerStateListener
 import com.android.installreferrer.api.ReferrerDetails
 import com.appsonair.applink.interfaces.AppLinkListener
+import com.appsonair.applink.utils.StringConst
 import com.appsonair.core.services.CoreService
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 import java.net.URI
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 
 class AppLinkService private constructor(private val context: Context) {
 
@@ -35,14 +43,68 @@ class AppLinkService private constructor(private val context: Context) {
         }
     }
 
-    private lateinit var listener: AppLinkListener
+    private var appLinkListener: AppLinkListener? = null
     private var referralLink = JSONObject()
-    private var referralDeferred: CompletableDeferred<JSONObject>? = null
 
+    /**
+     * The most recent successful post-expiry IP lookup. Held in memory only — like the response
+     * [currentReferral] returns, it describes the lookup that ran, not the install, so it must
+     * not replace the stored referral later launches read.
+     */
+    @Volatile
+    private var refreshedReferral: JSONObject? = null
+
+    @Volatile
+    private var refreshInFlight = false
+    private var referralDeferred: CompletableDeferred<JSONObject>? = null
+    private var isFirstLaunch = false
+    private var installReferrerParams = JSONObject()
+    private var clickTime = 0L
+    private var attributionStatus = StringConst.Organic
+    private var attributionTtlSeconds: Long? = null
+    private var installReported = false
+    private var launchStateResolved = false
+    private var startedActivityCount = 0
+    private var foregroundObserverRegistered = false
+    private var initialized = false
+    private var isBackgrounded = false
+
+    /**
+     * Set when backgrounding ends the first launch, and cleared by the return that follows.
+     * One-shot, so the attribution payload is re-delivered exactly once.
+     */
+    private var firstLaunchExpired = false
+
+    /**
+     * The single entry point. [AppLinkListener] carries every callback: [
+     * AppLinkListener.onDeepLinkProcessed], [AppLinkListener.onDeepLinkError],
+     * [AppLinkListener.onReferralLinkDetected] (deprecated, detection-only, `appsFlyer`
+     * removed) and [AppLinkListener.onAttributionListener], so one registration serves both
+     * the referral and the attribution surface.
+     */
     fun initialize(context: Context, intent: Intent, listener: AppLinkListener) {
-        this.listener = listener
+        this.appLinkListener = listener
+        startInitialization(context, intent)
+    }
+
+    /**
+     * Runs the one-time setup behind [initialize].
+     *
+     * Idempotent, because [initialize] can legitimately be called more than once: a cross-platform
+     * wrapper re-registers its listener on reload, and a host app may call it from more than one
+     * place. The listener assignment in [initialize] still takes effect, but repeating this work
+     * would re-deliver the same intent and fire onDeepLinkProcessed twice, as well as reconnect the
+     * install referrer client. iOS guards its deep link subscription the same way.
+     *
+     * A new intent arriving later is delivered through [handleDeepLink], not through here.
+     */
+    private fun startInitialization(context: Context, intent: Intent) {
+        if (initialized) return
+        initialized = true
+
         NetworkWatcherService.checkNetworkConnection(context)
         AppLinkHandler.appsOnAirAppId = CoreService.getAppId(context)
+        resolveLaunchState(context)
 
         // Fetch install referrer (if needed for initialization)
         fetchInstallReferrer {
@@ -50,6 +112,378 @@ class AppLinkService private constructor(private val context: Context) {
         }
         // Handle deep link processing immediately
         handleDeepLink(intent, "com.example.appsonair_android_applink")
+    }
+
+    /**
+     * Resolves the launch state used by the attribution fields.
+     *
+     * [isFirstLaunch] is true on the very first launch after installation and stays true only
+     * while the app remains in the foreground. See [observeForegroundState].
+     */
+    private fun resolveLaunchState(context: Context) {
+        // Resolved once per process: reading isFirstOpen also writes it, so a second
+        // initialize() call would otherwise report isFirstLaunch as false.
+        if (launchStateResolved) return
+        launchStateResolved = true
+
+        ServerTimeService.initialize(context)
+
+        val prefs = context.getSharedPreferences("Referral", Context.MODE_PRIVATE)
+        isFirstLaunch = !prefs.getBoolean("isFirstOpen", false)
+        if (isFirstLaunch) {
+            prefs.edit().putBoolean("isFirstOpen", true).apply()
+        }
+        installReferrerParams = getJsonFromPrefs(context, "install_referrer_params") ?: JSONObject()
+        clickTime = prefs.getLong("click_time", 0L)
+        attributionStatus = prefs.getString("attribution_status", StringConst.Organic)
+            ?: StringConst.Organic
+        attributionTtlSeconds = prefs.getLong("attribution_ttl", -1L).takeIf { it >= 0L }
+        installReported = prefs.getBoolean("install_reported", false)
+        observeForegroundState(context)
+    }
+
+    /**
+     * Tracks the foreground state to mirror the AppsFlyer session model.
+     *
+     * Leaving the foreground (backgrounded or phone locked) ends the first launch, so
+     * [isFirstLaunch] turns false without waiting for the process to restart. Coming back
+     * re-delivers the attribution payload, so the listener sees the current value instead of
+     * the one captured on the first launch.
+     */
+    private fun observeForegroundState(context: Context) {
+        if (foregroundObserverRegistered) return
+
+        val application = context.applicationContext as? Application
+        if (application == null) {
+            Log.d("AppLinkService", "Application unavailable, first launch ends with the process")
+            return
+        }
+        foregroundObserverRegistered = true
+
+        application.registerActivityLifecycleCallbacks(object :
+            Application.ActivityLifecycleCallbacks {
+            override fun onActivityStarted(activity: Activity) {
+                startedActivityCount++
+                // Only a real return from the background counts, not the first activity start.
+                if (startedActivityCount != 1 || !isBackgrounded) return
+
+                isBackgrounded = false
+
+                // One-shot: only the return that follows isFirstLaunch expiring re-delivers the
+                // payload. Later returns read the same persisted state, so they carry nothing new.
+                if (!firstLaunchExpired) return
+                firstLaunchExpired = false
+                notifyAttributionOnForeground()
+            }
+
+            override fun onActivityStopped(activity: Activity) {
+                startedActivityCount--
+                // A configuration change stops the activity too, but it is restarted right
+                // after, so it does not count as the app leaving the foreground.
+                if (startedActivityCount > 0 || activity.isChangingConfigurations) return
+
+                startedActivityCount = 0
+                isBackgrounded = true
+                if (isFirstLaunch) {
+                    isFirstLaunch = false
+                    firstLaunchExpired = true
+                    Log.d(
+                        "AppLinkService",
+                        "App left the foreground, isFirstLaunch is now false, " +
+                            "will notify on next return"
+                    )
+                }
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+            override fun onActivityResumed(activity: Activity) {}
+            override fun onActivityPaused(activity: Activity) {}
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+            override fun onActivityDestroyed(activity: Activity) {}
+        })
+    }
+
+    /**
+     * Re-delivers the cached attribution payload when the app returns to the foreground.
+     *
+     * Goes straight to the listener instead of [notifyAttributionDetected], so the persisted
+     * attribution status is not recomputed from cached data and the deprecated
+     * onReferralLinkDetected() keeps its detection-only behaviour.
+     */
+    private fun notifyAttributionOnForeground() {
+        val listener = appLinkListener ?: return
+        val cached = referralLink.takeIf { it.length() > 0 }
+            ?: getJsonFromPrefs(context, "referral_details")
+            ?: JSONObject()
+        Log.d("AppLinkService", "App returned to the foreground, isFirstLaunch=$isFirstLaunch")
+        listener.onAttributionListener(withAttribution(cached))
+    }
+
+    /**
+     * Resolves the click time from the install referrer.
+     *
+     * When the referrer carries the AppsFlyer params (pid appsonair, af_ad and any af_sub*),
+     * af_ad_id holds the click time. Otherwise it comes from applink_click_time on the
+     * appsonair_app_link itself.
+     */
+    private fun resolveClickTime(referrerUri: Uri, appsOnAirAppLink: String): Long {
+        val pid = referrerUri.getQueryParameter("pid").orEmpty()
+        val afAd = referrerUri.getQueryParameter("af_ad").orEmpty()
+        val hasAfSub = referrerUri.queryParameterNames.any {
+            it.startsWith("af_sub") && !referrerUri.getQueryParameter(it).isNullOrEmpty()
+        }
+
+        val rawClickTime = if (pid == "appsonair" && afAd.isNotEmpty() && hasAfSub) {
+            referrerUri.getQueryParameter("af_ad_id")
+        } else {
+            // applink_click_time may sit on the appsonair_app_link itself or alongside it
+            // as a referrer param, so check both.
+            appsOnAirAppLink.takeIf { it.isNotEmpty() }?.let {
+                val appLinkUri = Uri.parse(if (it.startsWith("http")) it else "https://$it")
+                appLinkUri.getQueryParameter("applink_click_time")
+            }?.takeIf { it.isNotEmpty() }
+                ?: referrerUri.getQueryParameter("applink_click_time")
+        }
+        return parseTimestamp(rawClickTime)
+    }
+
+    /**
+     * Parses an epoch timestamp given in either seconds or milliseconds and returns it in
+     * milliseconds, so it can be compared against [getFirstInstallTime]. Returns 0 when missing
+     * or not a valid timestamp.
+     */
+    private fun parseTimestamp(value: String?): Long {
+        val epoch = value?.trim()?.toLongOrNull()
+        if (epoch == null || epoch <= 0L) {
+            Log.d("AppLinkService", "Click time missing or invalid: $value")
+            return 0L
+        }
+        return if (epoch < 1_000_000_000_000L) epoch * 1000L else epoch
+    }
+
+    /**
+     * Reads attributionTtl (in seconds) from the referral response, checking the data object
+     * first and then the top level, and remembers it.
+     *
+     * Only the link response carries the ttl. Once the stored referral is the IP lookup result
+     * — or an error object — it is no longer in the payload, so the remembered value stands in
+     * for it and the window keeps being measured. Returns null when no response has carried it.
+     */
+    private fun attributionTtlFrom(result: JSONObject): Long? {
+        val source = result.optJSONObject("data")?.takeIf { it.has("attributionTtl") } ?: result
+        val ttlSeconds = source.optLong("attributionTtl", -1L)
+            .takeIf { source.has("attributionTtl") && it >= 0L }
+            ?: return attributionTtlSeconds
+
+        if (ttlSeconds != attributionTtlSeconds) {
+            attributionTtlSeconds = ttlSeconds
+            context.getSharedPreferences("Referral", Context.MODE_PRIVATE)
+                .edit().putLong("attribution_ttl", ttlSeconds).apply()
+        }
+        return ttlSeconds
+    }
+
+    /**
+     * An install is non-organic when it happened within attributionTtl of the click.
+     * Any missing or invalid input falls back to organic.
+     */
+    private fun resolveAttributionStatus(result: JSONObject): String {
+        if (clickTime <= 0L) return StringConst.Organic
+
+        val firstInstallTime = getFirstInstallTime()
+        if (firstInstallTime <= 0L) {
+            Log.d("AppLinkService", "First install time unavailable, defaulting to organic")
+            return StringConst.Organic
+        }
+
+        val ttlSeconds = attributionTtlFrom(result)
+        if (ttlSeconds == null) {
+            Log.d("AppLinkService", "attributionTtl unavailable, defaulting to organic")
+            return StringConst.Organic
+        }
+
+        val differenceSeconds = (firstInstallTime - clickTime) / 1000
+        return if (differenceSeconds <= ttlSeconds) {
+            StringConst.NonOrganic
+        } else {
+            StringConst.Organic
+        }
+    }
+
+    /**
+     * True when [result] is a referral the server actually matched, rather than an error or an
+     * empty body. Both identifiers are required, since they are what names the link this install
+     * came from — [getReferralUsingIp] counts the install off the same pair.
+     */
+    private fun hasReferralMatch(result: JSONObject): Boolean {
+        if (result.has("error")) return false
+        val data = result.optJSONObject("data") ?: return false
+        return data.optString("shortId").isNotEmpty() &&
+            data.optString("referralLink").isNotEmpty()
+    }
+
+    /**
+     * The status for a referral matched by IP instead of by the install referrer.
+     *
+     * The referrer carried no usable click time — it named no link, or the click param was missing
+     * or unparseable — so [resolveAttributionStatus] has nothing to measure and would report
+     * organic on that basis alone. The IP lookup can still name the link this install came from,
+     * so the match decides it instead: attributed while it is inside attributionTtl, organic once
+     * it is not.
+     *
+     * There is no click to measure from, so [isAttributionTtlExpired] runs the window from the
+     * install. It also treats a ttl that has never been seen, and a clock that has been wound
+     * back, as expired — both leave the match unverifiable, which is the organic answer either way.
+     */
+    private fun resolveIpAttributionStatus(result: JSONObject): String {
+        if (!hasReferralMatch(result)) {
+            Log.d("AppLinkService", "IP lookup matched no referral, defaulting to organic")
+            return StringConst.Organic
+        }
+        return if (isAttributionTtlExpired(result)) {
+            Log.d("AppLinkService", "IP referral matched but attributionTtl has elapsed")
+            StringConst.Organic
+        } else {
+            StringConst.NonOrganic
+        }
+    }
+
+    private fun updateAttributionStatus(result: JSONObject, matchedByIp: Boolean = false) {
+        attributionStatus = if (matchedByIp) {
+            resolveIpAttributionStatus(result)
+        } else {
+            resolveAttributionStatus(result)
+        }
+        Log.d("AppLinkService", "Attribution status resolved: $attributionStatus")
+        context.getSharedPreferences("Referral", Context.MODE_PRIVATE)
+            .edit().putString("attribution_status", attributionStatus).apply()
+    }
+
+    /**
+     * Stores every install referrer param except appsonair_app_link, so they stay available
+     * on later launches when the referrer is no longer fetched.
+     */
+    private fun storeInstallReferrerParams(referrerUri: Uri) {
+        val params = JSONObject()
+        referrerUri.queryParameterNames
+            .filter { it != "appsonair_app_link" }
+            .forEach { params.put(it, referrerUri.getQueryParameter(it).orEmpty()) }
+        installReferrerParams = params
+        saveJsonToPrefs(context, "install_referrer_params", params)
+    }
+
+    private fun storeClickTime(referrerUri: Uri, appsOnAirAppLink: String) {
+        clickTime = resolveClickTime(referrerUri, appsOnAirAppLink)
+        context.getSharedPreferences("Referral", Context.MODE_PRIVATE)
+            .edit().putLong("click_time", clickTime).apply()
+    }
+
+    /**
+     * Reports the install to the link count API and waits up to the timeout for its result.
+     *
+     * [installReported] turns true only here, and only when the call succeeds. It is persisted
+     * so the install is counted once and later launches do not report it again.
+     */
+    private suspend fun countInstall(linkId: String, domain: String) {
+        val counted = CompletableDeferred<Boolean>()
+        AppLinkHandler.handleLinkCount(
+            linkId,
+            domain,
+            isClicked = false,
+            isFirstOpen = true,
+            isInstall = true,
+        ) { isSuccessful ->
+            if (isSuccessful && !installReported) {
+                installReported = true
+                context.getSharedPreferences("Referral", Context.MODE_PRIVATE)
+                    .edit().putBoolean("install_reported", true).apply()
+            }
+            counted.complete(isSuccessful)
+        }
+        withTimeoutOrNull(2_000L) { counted.await() }
+    }
+
+    /**
+     * The install referrer keys exposed in the attribution payload.
+     *
+     * With AppsFlyer enabled the link carries a copy of its detail (`pid`, `c` and the `af_`
+     * prefixed params). That copy is dropped, so the `appsFlyer` object returned by the API stays
+     * the only place the AppsFlyer detail is read from.
+     */
+    private fun exposedInstallReferrerKeys(): List<String> {
+        val keys = installReferrerParams.keys().asSequence().toList()
+        if (keys.none { it.startsWith("af_") }) return keys
+        return keys.filterNot { it.startsWith("af_") || it == "pid" || it == "c" }
+    }
+
+    /**
+     * Returns a copy of [result] with the attribution fields added, leaving the
+     * original untouched so the deprecated referral APIs keep their existing payload.
+     */
+    private fun withAttribution(result: JSONObject): JSONObject {
+        return JSONObject(result.toString()).apply {
+            val referralData = optJSONObject("data")
+            val data = referralData ?: JSONObject().also { put("data", it) }
+            data.put("isFirstLaunch", isFirstLaunch)
+            data.put("firstInstallTime", getFirstInstallTime())
+            // Consumed means the click was attributed to this install. An install outside
+            // attributionTtl is organic, so nothing was claimed.
+            data.put("isConsumed", attributionStatus == StringConst.NonOrganic)
+            data.put("attributionStatus", attributionStatus)
+            // The click time behind attributionStatus: af_ad_id with AppsFlyer enabled, and
+            // applink_click_time on the appsonair_app_link otherwise. Normalised to epoch
+            // milliseconds by resolveClickTime, so it lines up with firstInstallTime. Left out
+            // when there is no click to report.
+            if (clickTime > 0L) {
+                data.put("applink_click_time", clickTime)
+            }
+            // Install referrer params, without overriding the link details from the response
+            exposedInstallReferrerKeys().forEach { key ->
+                if (!data.has(key)) {
+                    data.put(key, installReferrerParams.get(key))
+                }
+            }
+        }
+    }
+
+    private fun getFirstInstallTime(): Long {
+        return try {
+            context.packageManager.getPackageInfo(context.packageName, 0).firstInstallTime
+        } catch (e: Exception) {
+            Log.e("AppLinkService", "Failed to read first install time: ${e.message}")
+            0L
+        }
+    }
+
+    private fun notifyDeepLinkProcessed(uri: Uri, result: JSONObject) {
+        appLinkListener?.onDeepLinkProcessed(uri, result)
+    }
+
+    private fun notifyDeepLinkError(uri: Uri?, error: String) {
+        appLinkListener?.onDeepLinkError(uri, error)
+    }
+
+    /**
+     * Returns a copy of [result] without the `appsFlyer` object, leaving the original untouched.
+     * The API returns `appsFlyer` on the dynamic-link and referral/details endpoints, but it is
+     * part of the newer attribution surface: only [getAttributionInfo] and
+     * [AppLinkListener.onAttributionListener] expose it, so the deprecated referral APIs and
+     * the deprecated [AppLinkListener.onReferralLinkDetected] callback keep their original
+     * payload shape.
+     * Removed at both levels because the key may sit at the root or inside `data`.
+     */
+    private fun withoutAppsFlyer(result: JSONObject): JSONObject {
+        return JSONObject(result.toString()).apply {
+            remove("appsFlyer")
+            optJSONObject("data")?.remove("appsFlyer")
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun notifyAttributionDetected(result: JSONObject, matchedByIp: Boolean = false) {
+        updateAttributionStatus(result, matchedByIp)
+        appLinkListener?.onReferralLinkDetected(withoutAppsFlyer(result))
+        appLinkListener?.onAttributionListener(withAttribution(result))
     }
 
     suspend fun createAppLink(
@@ -64,6 +498,8 @@ class AppLinkService private constructor(private val context: Context) {
         isOpenInBrowserApple: Boolean? = null,
         isOpenInIosApp: Boolean? = null,
         iosFallbackUrl: String? = null,
+        appsFlyer: Map<String, Any>? = null,
+        attributionTtl: Int? = null,
     ): JSONObject {
 
         return AppLinkHandler.createAppLink(
@@ -78,18 +514,164 @@ class AppLinkService private constructor(private val context: Context) {
             isOpenInBrowserApple = isOpenInBrowserApple,
             isOpenInIosApp = isOpenInIosApp,
             iosFallbackUrl = iosFallbackUrl,
+            appsFlyer = appsFlyer,
+            attributionTtl = attributionTtl,
         )
     }
 
+    /**
+     * Serves the freshest referral already held: the last post-expiry lookup when one has run,
+     * the stored referral otherwise.
+     *
+     * This call does not suspend, so it cannot wait for a lookup the way [getReferralInfo] and
+     * [getAttributionInfo] do. Once attributionTtl has elapsed it starts one in the background
+     * instead, which leaves the first expired call returning the stored referral and later calls
+     * returning the refreshed one.
+     */
     @Deprecated(
-        message = "Use getReferralInfo() instead",
-        replaceWith = ReplaceWith("getReferralInfo()")
+        message = "Use getAttributionInfo() instead",
+        replaceWith = ReplaceWith("getAttributionInfo()")
     )
     fun getReferralDetails(): JSONObject {
-        return referralLink
+        val latest = refreshedReferral ?: referralLink
+        if (isAttributionTtlExpired(latest)) {
+            refreshReferralInBackground()
+        }
+        return withoutAppsFlyer(latest)
     }
 
+    @Deprecated(
+        message = "Use getAttributionInfo() instead",
+        replaceWith = ReplaceWith("getAttributionInfo()")
+    )
     suspend fun getReferralInfo(): JSONObject {
+        return withoutAppsFlyer(currentReferral())
+    }
+
+    /**
+     * True when attributionTtl has elapsed since the click, measured against the clock right now
+     * rather than against the install time. This is a live check, so it is independent of
+     * [attributionStatus]: an install attributed at first launch still expires once enough time
+     * passes.
+     *
+     * Unknown inputs count as expired: a ttl that has never been seen, or neither a click time nor
+     * an install time to measure the window from. Expiry cannot be demonstrated in either case, so
+     * the referral is refreshed rather than trusted. A device clock that predates the click or the
+     * install also counts as expired: see the comment below.
+     */
+    private fun isAttributionTtlExpired(referral: JSONObject): Boolean {
+        val ttlSeconds = attributionTtlFrom(referral) ?: return true
+
+        val firstInstallTime = getFirstInstallTime()
+        // The window runs from the click. An organic install has none, and neither does a
+        // referrer that carried no click time, so the install stands in for it: the stored
+        // referral stops being current once the ttl has passed either way.
+        val windowStart = if (clickTime > 0L) clickTime else firstInstallTime
+        if (windowStart <= 0L) return true
+
+        // Corrected by the last server Date header, so a device clock that is merely wrong still
+        // measures the window correctly. See ServerTimeService for what this does and does not stop.
+        val now = ServerTimeService.now()
+
+        // Time only moves forward. Corrected now falling behind something already observed means
+        // the clock was wound back between observations.
+        if (ServerTimeService.hasClockRewound()) {
+            Log.d("AppLinkService", "Clock moved backwards, treating attribution as expired")
+            return true
+        }
+
+        // clickTime is stamped by the link service and firstInstallTime by PackageManager, so
+        // neither can be edited from Settings. A now that predates either one is impossible on an
+        // honest clock, and would otherwise shrink the elapsed time and hold the window open.
+        // Treat it as expired so the backend decides, rather than trusting a clock that has lied.
+        if (now < windowStart || (firstInstallTime > 0L && now < firstInstallTime)) {
+            Log.d(
+                "AppLinkService",
+                "Clock ($now) predates click ($clickTime) or install ($firstInstallTime), " +
+                    "treating attribution as expired"
+            )
+            return true
+        }
+
+        ServerTimeService.observe(now)
+
+        val elapsedSeconds = (now - windowStart) / 1000
+        return elapsedSeconds > ttlSeconds
+    }
+
+    /**
+     * The referral that describes this install right now.
+     *
+     * Once attributionTtl has elapsed since the click — or since the install, when there is no
+     * click — the stored referral no longer describes this install, so it is re-read from the IP
+     * lookup on every call and that response is returned in its place. This depends on the ttl
+     * alone, not on [attributionStatus]: an organic install refreshes on the same schedule.
+     * Inside the window the stored referral is served as-is.
+     *
+     * The refreshed response is deliberately not stored: it describes the lookup that just ran,
+     * not the install, so it must not replace the referral later launches read.
+     *
+     * A failed lookup falls back to the stored referral rather than surfacing the error object
+     * to the host app.
+     */
+    private suspend fun currentReferral(): JSONObject {
+        // The ttl lives inside the stored referral, so it has to be read before the check.
+        val storedReferral = awaitReferralInfo()
+        if (!isAttributionTtlExpired(storedReferral)) return storedReferral
+        return lookupReferralByIP() ?: storedReferral
+    }
+
+    /**
+     * Runs the IP lookup and caches it in [refreshedReferral], so [getReferralDetails] can serve
+     * it without suspending. Returns null when the lookup fails, leaving callers to fall back to
+     * the stored referral.
+     */
+    private suspend fun lookupReferralByIP(): JSONObject? {
+        // getUserAgent() instantiates a WebView, which must happen on the main thread.
+        val ipResult = AppLinkHandler.getReferralLinkByIP(
+            withContext(Dispatchers.Main) { getUserAgent() }
+        )
+        if (ipResult.length() > 0 && !ipResult.has("error")) {
+            refreshedReferral = ipResult
+            return ipResult
+        }
+
+        Log.d(
+            "AppLinkService",
+            "IP referral lookup failed after attributionTtl expiry, falling back to stored referral"
+        )
+        return null
+    }
+
+    /**
+     * Starts a lookup for [getReferralDetails], which cannot suspend to wait for one. At most one
+     * runs at a time, so repeated calls past expiry do not pile up requests.
+     */
+    private fun refreshReferralInBackground() {
+        if (refreshInFlight) return
+        refreshInFlight = true
+        CoroutineScope(Dispatchers.Main).launch {
+            try {
+                lookupReferralByIP()
+            } finally {
+                refreshInFlight = false
+            }
+        }
+    }
+
+    /**
+     * Returns the attribution details — [isFirstLaunch], [firstInstallTime], applink_click_time,
+     * [isConsumed] and [attributionStatus] — on top of the referral [currentReferral] resolves.
+     *
+     * [attributionStatus] is deliberately left alone: it stays as it resolved at install time, so
+     * it and [isConsumed] keep reporting what was attributed even once the payload carries the IP
+     * based referral.
+     */
+    suspend fun getAttributionInfo(): JSONObject {
+        return withAttribution(currentReferral())
+    }
+
+    private suspend fun awaitReferralInfo(): JSONObject {
         // Case 1: already in memory
         if (referralLink.length() > 0) {
             return referralLink
@@ -168,6 +750,8 @@ class AppLinkService private constructor(private val context: Context) {
                         val appsOnAirAppLink =
                             uriPlaceHolder.getQueryParameter("appsonair_app_link")
                                 .orEmpty()
+                        storeInstallReferrerParams(uriPlaceHolder)
+                        storeClickTime(uriPlaceHolder, appsOnAirAppLink)
                         val schemeUri = Uri.parse(
                             if (appsOnAirAppLink.startsWith("http")) appsOnAirAppLink else "https://$appsOnAirAppLink"
                         )//Appending https if not exist in url to get accurate data
@@ -181,28 +765,41 @@ class AppLinkService private constructor(private val context: Context) {
                                 .putBoolean("isAppInstalled", true)
                                 .apply()
                             if (linkId.isNotEmpty() && domain.isNotEmpty()) {
-                                AppLinkHandler.handleLinkCount(
-                                    linkId,
-                                    domain,
-                                    isClicked = false,
-                                    isFirstOpen = true,
-                                    isInstall = true
-                                )
                                 if (schemeUri.toString().isNotEmpty()) {
                                     CoroutineScope(Dispatchers.Main).launch {
+                                        countInstall(linkId, domain)
 
-                                        var result = getFullReferralDetails(
+                                        val referrerResult = getFullReferralDetails(
                                             domain,
                                             linkId,
                                             schemeUri.toString()
                                         )
 
-                                        delay(750) // Wait for sometime to trigger listener
-                                        listener.onReferralLinkDetected(
-                                            result
-                                        )
-                                        val publicUserAgent = getUserAgent()
-                                        AppLinkHandler.getReferralLinkByIP(publicUserAgent) //Just for avoiding the conflicts I'm calling this api when app reinstall
+                                        // The install referrer link only attributes this install
+                                        // while the click sits inside attributionTtl. Once the click
+                                        // falls outside it, that link is not this install's referral,
+                                        // so its data is replaced by the IP based lookup.
+                                        // resolveAttributionStatus also reports Organic when the
+                                        // click time, install time or ttl are missing — the same
+                                        // conclusion, since the link cannot be attributed either way.
+                                        if (resolveAttributionStatus(referrerResult) == StringConst.Organic) {
+                                            delay(750) // Wait for sometime to trigger listener
+
+                                            val publicUserAgent = getUserAgent()
+                                            val ipResult =
+                                                AppLinkHandler.getReferralLinkByIP(publicUserAgent)
+
+                                            // Overwrite what getFullReferralDetails cached, so the
+                                            // referral APIs and later launches read the IP result.
+                                            referralLink = ipResult
+                                            saveJsonToPrefs(context, "referral_details", ipResult)
+                                            referralDeferred?.complete(ipResult)
+                                            referralDeferred = null
+
+                                            notifyAttributionDetected(ipResult, matchedByIp = true)
+                                        } else {
+                                            notifyAttributionDetected(referrerResult)
+                                        }
                                     }
                                 }
                             } else {
@@ -253,9 +850,6 @@ class AppLinkService private constructor(private val context: Context) {
         saveJsonToPrefs(context, "referral_details", data)
         delay(500) // Wait for sometime to trigger listener
         referralDeferred?.complete(data) //  notify waiter
-        listener.onReferralLinkDetected(
-            data
-        )
 
         if (dataObject != null) {
             val shortId = dataObject.optString("shortId", "")
@@ -263,15 +857,10 @@ class AppLinkService private constructor(private val context: Context) {
 
             if (shortId.isNotEmpty() && referralLink.isNotEmpty()) {
                 val domain = URI(referralLink).host
-                AppLinkHandler.handleLinkCount(
-                    shortId,
-                    domain,
-                    isClicked = false,
-                    isFirstOpen = true,
-                    isInstall = true
-                )
+                countInstall(shortId, domain)
             }
         }
+        notifyAttributionDetected(data, matchedByIp = true)
     }
 
     private fun saveJsonToPrefs(context: Context, key: String, jsonObject: JSONObject) {
@@ -304,7 +893,12 @@ class AppLinkService private constructor(private val context: Context) {
         referLink: String
     ): JSONObject {
         return try {
-            val result = AppLinkHandler.fetchAppLink(linkId, domain)
+            // getUserAgent() instantiates a WebView, which must happen on the main thread.
+            val result = AppLinkHandler.fetchAppLink(
+                linkId,
+                domain,
+                withContext(Dispatchers.Main) { getUserAgent() }
+            )
             if (result.has("data") && !result.isNull("data")) {
                 val dataObj = result.getJSONObject("data")
                 dataObj.put("referralLink", referLink)
@@ -360,12 +954,15 @@ class AppLinkService private constructor(private val context: Context) {
                 domain = schemeUri.host.orEmpty()
             }
             if(linkId.isEmpty()){
-                listener.onDeepLinkProcessed(uri, JSONObject())
+                notifyDeepLinkProcessed(uri, JSONObject())
                 return@launch
             }
             AppLinkHandler.handleLinkCount(linkId, domain, isClick)
-            val result = AppLinkHandler.fetchAppLink(linkId, domain)
-            listener.onDeepLinkProcessed(uri, result.optJSONObject("data") ?: result)
+
+            // The link the deep link points at, fetched fresh, matching what iOS delivers here.
+            // Already on the main dispatcher, which getUserAgent() requires for its WebView.
+            val result = AppLinkHandler.fetchAppLink(linkId, domain, getUserAgent())
+            notifyDeepLinkProcessed(uri, result.optJSONObject("data") ?: result)
         }
     }
 
@@ -374,7 +971,7 @@ class AppLinkService private constructor(private val context: Context) {
      */
     private fun onDeepLinkError(uri: Uri?, error: String) {
         // Handle deep link error logic here if needed (e.g., logging, analytics)
-        listener.onDeepLinkError(uri, error)
+        notifyDeepLinkError(uri, error)
     }
 
 

--- a/applink/src/main/java/com/appsonair/applink/services/ServerTimeService.kt
+++ b/applink/src/main/java/com/appsonair/applink/services/ServerTimeService.kt
@@ -1,0 +1,95 @@
+package com.appsonair.applink.services
+
+import android.content.Context
+import android.util.Log
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Keeps the SDK's notion of "now" independent of the device clock, which is the one input in the
+ * attributionTtl comparison that the user can edit from Settings.
+ *
+ * Every API response carries an RFC 1123 `Date` header stamped by the server. The difference
+ * between it and the device clock is persisted as an offset, so a device whose clock is simply
+ * wrong — never synced, reset by a flat battery — still measures attributionTtl correctly.
+ *
+ * Alongside it a high-water mark of the newest corrected time ever observed is persisted. Real
+ * time only moves forward, so a corrected now that falls behind that mark means the clock was
+ * rewound between two observations.
+ *
+ * **Known limit, deliberately not papered over.** The offset is only refreshed when a request
+ * happens, so a clock moved *after* the last capture drags the corrected time with it. The
+ * high-water mark catches that only once the rewound time falls behind something already seen —
+ * it cannot tell "the app was closed for 3 minutes" from "the app was closed for 3 hours and the
+ * clock was wound back". Closing that gap needs the backend to decide expiry; it is not solvable
+ * on the device.
+ */
+internal object ServerTimeService {
+
+    private const val PREFS = "Referral"
+    private const val OFFSET_KEY = "server_time_offset"
+    private const val HIGH_WATER_KEY = "server_time_high_water"
+
+    private var appContext: Context? = null
+
+    @Volatile
+    private var offsetMillis = 0L
+
+    @Volatile
+    private var highWaterMillis = 0L
+
+    /** Restores the persisted offset and high-water mark. Safe to call more than once. */
+    fun initialize(context: Context) {
+        appContext = context.applicationContext
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        offsetMillis = prefs.getLong(OFFSET_KEY, 0L)
+        highWaterMillis = prefs.getLong(HIGH_WATER_KEY, 0L)
+        Log.d("ServerTimeService", "Restored offset=${offsetMillis}ms highWater=$highWaterMillis")
+    }
+
+    /**
+     * Records the server clock from a response `Date` header. Called for every API response, so a
+     * malformed or absent header is ignored rather than logged loudly.
+     */
+    fun recordServerDate(header: String?) {
+        val serverMillis = header?.let(::parseHttpDate) ?: return
+        offsetMillis = serverMillis - System.currentTimeMillis()
+        persist(OFFSET_KEY, offsetMillis)
+        observe(serverMillis)
+    }
+
+    /** The device clock corrected by the last known server offset. */
+    fun now(): Long = System.currentTimeMillis() + offsetMillis
+
+    /** True when corrected time has moved behind the newest time already observed. */
+    fun hasClockRewound(): Boolean = highWaterMillis > 0L && now() < highWaterMillis
+
+    /** Advances the high-water mark. Never moves it backwards. */
+    fun observe(correctedMillis: Long = now()) {
+        if (correctedMillis > highWaterMillis) {
+            highWaterMillis = correctedMillis
+            persist(HIGH_WATER_KEY, correctedMillis)
+        }
+    }
+
+    /**
+     * Parses the RFC 1123 form HTTP requires for `Date`. `SimpleDateFormat` is not thread safe and
+     * responses arrive on arbitrary threads, so the instance is built per call.
+     */
+    private fun parseHttpDate(header: String): Long? {
+        return try {
+            SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+                .apply { timeZone = TimeZone.getTimeZone("GMT") }
+                .parse(header)?.time
+        } catch (e: Exception) {
+            Log.d("ServerTimeService", "Unparseable Date header: $header")
+            null
+        }
+    }
+
+    private fun persist(key: String, value: Long) {
+        appContext?.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            ?.edit()?.putLong(key, value)?.apply()
+    }
+}

--- a/applink/src/main/java/com/appsonair/applink/utils/StringConst.kt
+++ b/applink/src/main/java/com/appsonair/applink/utils/StringConst.kt
@@ -6,8 +6,16 @@ internal class StringConst {
         const val AppLinkCreate = "dynamic-link/"
         const val Config = AppLinkCreate + "config/"
         const val ApplicatonKey = "x-application-key"
+
+        /// Sent on every API request so the backend can attribute behaviour to an SDK release.
+        /// The value comes from BuildConfig.VERSION_NAME, wired up in applink/build.gradle.kts.
+        const val SdkVersionKey = "x-sdk-version"
         const val Referrer = AppLinkCreate + "referral/details"
         const val LinkAnalytics = "dynamic-link-analytics/"
+
+        ///Attribution
+        const val Organic = "organic"
+        const val NonOrganic = "non-organic"
 
         ///Common
         const val NetworkError = "No Network Available!"

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 BASE_URL=https://server.appsonair.link/api/
 VERSION_CODE=1
-VERSION_NAME=1.3.3
+VERSION_NAME=2.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Tue Nov 26 13:29:13 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 2.0.0

* `getReferralInfo()` is now deprecated, use `getAttributionInfo()` instead.

* Introduced `getAttributionInfo()` method.
    * Returns the same data as `getReferralInfo()` with additional `isFirstLaunch`, `firstInstallTime`, `isConsumed` and `attributionStatus` fields included in the response.

* Introduced `onAttributionListener()` listener.
    * When an attribution is detected, and again every time the app returns to the foreground so the payload stays current.

* Added `appsFlyer` and `attributionTtl` params to `AppLinkParams` for AppsFlyer attribution support in `createAppLink` method.

**Deprecated:**

* `onReferralLinkDetected()` — use `onAttributionListener()`.
* `getReferralInfo()` and `getReferralDetails()` — use `getAttributionInfo()`.